### PR TITLE
fix build.xml to included jgoodies

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -66,7 +66,7 @@
 
     <!-- Default JAR libraries -->
     <!-- Libraries used at compile time only -->
-    <property name="forms.jar" location="${lib.dir}/jgoodies-forms-1.4.0.jar"/>
+    <property name="forms.jar" location="${lib.dir}/jgoodies-forms-1.7.1.jar"/>
     <property name="mac_ui.jar" location="${lib.dir}/ui.jar"/>    
     <!-- Libraries used for sample code only -->
     <property name="jcalendar.jar" location="${lib.dir}/jcalendar-1.3.3.jar"/>


### PR DESCRIPTION
This little fix prevents swixml to build from a clean checkout.
